### PR TITLE
fix deprecated pandas sort method

### DIFF
--- a/1c-python-pandas.txt
+++ b/1c-python-pandas.txt
@@ -8,11 +8,7 @@ import pandas as pd
 %time dm = pd.read_csv("/tmp/dm.csv", header = None, names=["x"])
 
 
-%time d.groupby("x", as_index = False)["y"].mean().sort("y", ascending = False).head(5)
-%time d.groupby("x")["y"].mean().order(ascending = False)[:5]
+%time d.groupby("x", as_index = False)["y"].mean().sort_values("y", ascending = False).head(5)
+%time d.groupby("x")["y"].mean().sort_values(ascending = False)[:5]
 
 %time pd.merge(d, dm).shape[0]
-
-
-
-


### PR DESCRIPTION
`pandas.DataFrame.sort()` was deprecated in pandas 0.18 and removed in 0.20 so the script no longer works.

This is a simple change but will allow it to work with modern pip installs of pandas.

http://pandas.pydata.org/pandas-docs/version/0.18.1/generated/pandas.DataFrame.sort.html